### PR TITLE
only enable the ops-rpm repo for rpm installs

### DIFF
--- a/ops-build-refresh-and-push-osohm-container.sh
+++ b/ops-build-refresh-and-push-osohm-container.sh
@@ -70,7 +70,7 @@ fi
 
 sudo docker build ${NOCACHE} -t registry.reg-aws.openshift.com:443/ops/oso-rhel7-host-monitoring:${ENVIRONMENT} -<<EOF
 FROM registry.reg-aws.openshift.com:443/ops/oso-rhel7-host-monitoring:${ENVIRONMENT}
-RUN yum-install-check.sh -y \
+RUN yum-install-check.sh -y --disablerepo=* --enablerepo=ops-rpm \
         python-openshift-tools \
         python-openshift-tools-monitoring-pcp \
         python-openshift-tools-monitoring-docker \


### PR DESCRIPTION
all the packages we want to install are in the ops-rpm repo, so we can save a little more time by disabling the other 19 or so repos during the build.